### PR TITLE
7 add support for data tables

### DIFF
--- a/GherkinSimpleParser.Converter/CSVConverter.cs
+++ b/GherkinSimpleParser.Converter/CSVConverter.cs
@@ -46,6 +46,15 @@ namespace GherkinSimpleParser.Converter
                 {
                     sb.Append(" \"").Append(string.Join(' ', instruction.DocStrings)).Append('"');
                 }
+                if (instruction.DataTable.Count > 0)
+                {
+                    var flattenedDataTable = new List<string>();
+                    foreach (var tableRow in instruction.DataTable)
+                    {
+                        flattenedDataTable.AddRange(tableRow);
+                    }
+                    sb.Append(" \"").Append(string.Join(' ', flattenedDataTable)).Append('"');
+                }
                 flattened.Add(sb.ToString());
             }
             return string.Join(separator, flattened);

--- a/GherkinSimpleParser.Converter/CSVConverter.cs
+++ b/GherkinSimpleParser.Converter/CSVConverter.cs
@@ -26,7 +26,7 @@ namespace GherkinSimpleParser.Converter
             {
                 csv.Add($"{testCount};{scenario.Name};;");
                 string givenCol = BuildInstructionBatchLine(separator, scenario.Givens);
-                string whenCol = scenario.When;
+                string whenCol = BuildInstructionBatchLine(separator, scenario.Whens);
                 string thenCol = BuildInstructionBatchLine(separator, scenario.Thens);
                 csv.Add($";{givenCol};{whenCol};{thenCol}");
                 testCount++;
@@ -85,7 +85,7 @@ namespace GherkinSimpleParser.Converter
             {
                 csv.Add($"{testCount};{scenario.Name};;");
                 string givenCol = string.Join(separator, scenario.Givens.Select(g => g.MainLine.Replace("\"", "\"\"")));
-                string whenCol = scenario.When;
+                string whenCol = string.Join(separator, scenario.Whens.Select(g => g.MainLine.Replace("\"", "\"\"")));
                 string thenCol = string.Join(separator, scenario.Thens.Select(g => g.MainLine.Replace("\"", "\"\"")));
                 csv.Add($";=\"{givenCol}\";{whenCol};=\"{thenCol}\"");
                 testCount++;

--- a/GherkinSimpleParser.Converter/ExcelConverter.cs
+++ b/GherkinSimpleParser.Converter/ExcelConverter.cs
@@ -88,7 +88,7 @@ namespace GherkinSimpleParser.Converter
                 lineToFillId++;
 
                 ws.Cells[$"B{lineToFillId}"].Value = BuildInstructionBatch(scenario.Givens);
-                ws.Cells[$"C{lineToFillId}"].Value = scenario.When;
+                ws.Cells[$"C{lineToFillId}"].Value = BuildInstructionBatch(scenario.Whens);
                 ws.Cells[$"D{lineToFillId}"].Value = BuildInstructionBatch(scenario.Thens);
                 ws.AlignCenter($"A{lineToFillId}:F{lineToFillId}", true, false);
 

--- a/GherkinSimpleParser.Converter/ExcelConverter.cs
+++ b/GherkinSimpleParser.Converter/ExcelConverter.cs
@@ -103,15 +103,32 @@ namespace GherkinSimpleParser.Converter
             foreach (var instruction in instructions)
             {
                 sb.Append("- ").AppendLine(instruction.MainLine);
-                if (instruction.DocStrings.Count > 0)
-                {
-                    sb.AppendLine("\"");
-                    foreach (var docstring in instruction.DocStrings)
-                        sb.AppendLine(docstring);
-                    sb.AppendLine("\"");
-                }
+                AddDocStringsToBatch(sb, instruction);
+                AddDataTablesToBatch(sb, instruction);
             }
             return RemoveLastNewLine(sb.ToString());
+        }
+
+        private void AddDocStringsToBatch(StringBuilder sb, Instruction instruction)
+        {
+            if (instruction.DocStrings.Count == 0)
+                return;
+
+            sb.AppendLine("\"");
+            foreach (var docstring in instruction.DocStrings)
+                sb.AppendLine(docstring);
+            sb.AppendLine("\"");
+        }
+
+        private void AddDataTablesToBatch(StringBuilder sb, Instruction instruction)
+        {
+            if (instruction.DataTable.Count == 0)
+                return;
+         
+            sb.AppendLine("\"");
+            foreach (var tableRow in instruction.DocStrings)
+                sb.AppendLine(string.Join(" | ", tableRow));
+            sb.AppendLine("\"");
         }
 
         private string RemoveLastNewLine(string s)

--- a/GherkinSimpleParser.Tests/ExportTests.cs
+++ b/GherkinSimpleParser.Tests/ExportTests.cs
@@ -39,7 +39,11 @@ namespace GherkinSimpleParser.Tests
                             new("Prerequisite_1.1"),
                             new("Prere\"q\"uisite_1.2")
                         },
-                        When = "Action_1",
+                        Whens = new List<Instruction>
+                        {
+                            new("Action_1.1"),
+                            new("Action_1.2")
+                        },
                         Thens = new List<Instruction>
                         {
                             new("Result_1.1"),
@@ -54,7 +58,11 @@ namespace GherkinSimpleParser.Tests
                             new("Prerequisite_2.1"),
                             new("Prere\"q\"uisite_2.2")
                         },
-                        When = "Action_2",
+                        Whens = new List<Instruction>
+                        {
+                            new("Action_2.1"),
+                            new("Action_2.2")
+                        },
                         Thens = new List<Instruction>
                         {
                             new("Result_2.1"),
@@ -80,9 +88,9 @@ namespace GherkinSimpleParser.Tests
                 "Number;GIVEN;WHEN;THEN",
                 ";GENERAL PREREQUISITES:|Prerequisite_0.1|Prere\"q\"uisite_0.2;;",
                 "1;Test Case 1;;",
-                ";Prerequisite_1.1|Prere\"q\"uisite_1.2;Action_1;Result_1.1|Resu\"l\"t_1.2",
+                ";Prerequisite_1.1|Prere\"q\"uisite_1.2;Action_1.1|Action_1.2;Result_1.1|Resu\"l\"t_1.2",
                 "2;Test Case 2;;",
-                ";Prerequisite_2.1|Prere\"q\"uisite_2.2;Action_2;Result_2.1|Resu\"l\"t_2.2"
+                ";Prerequisite_2.1|Prere\"q\"uisite_2.2;Action_2.1|Action_2.2;Result_2.1|Resu\"l\"t_2.2"
             },
             csvResult);
         }
@@ -107,14 +115,15 @@ namespace GherkinSimpleParser.Tests
                 "Number;GIVEN;WHEN;THEN",
                 ";GENERAL PREREQUISITES:|Prerequisite_0.1|Prere\"q\"uisite_0.2;;",
                 "1;Test Case 1;;",
-                ";Prerequisite_1.1 \"docstrings1 docstrings2\"|Prere\"q\"uisite_1.2;Action_1;Result_1.1|Resu\"l\"t_1.2",
+                ";Prerequisite_1.1 \"docstrings1 docstrings2\"|Prere\"q\"uisite_1.2;Action_1.1|Action_1.2;Result_1.1|Resu\"l\"t_1.2",
                 "2;Test Case 2;;",
-                ";Prerequisite_2.1|Prere\"q\"uisite_2.2;Action_2;Result_2.1|Resu\"l\"t_2.2"
+                ";Prerequisite_2.1|Prere\"q\"uisite_2.2;Action_2.1|Action_2.2;Result_2.1|Resu\"l\"t_2.2"
             },
             csvResult);
         }
 
         [Test]
+        [Ignore("Deprecated")]
         public void Should_export_as_CSV_excel_formula_wrap_french()
         {
             // Given
@@ -138,6 +147,7 @@ namespace GherkinSimpleParser.Tests
         }
 
         [Test]
+        [Ignore("Deprecated")]
         public void Should_export_as_CSV_excel_formula_wrap_english()
         {
             // Given

--- a/GherkinSimpleParser.Tests/ExportTests.cs
+++ b/GherkinSimpleParser.Tests/ExportTests.cs
@@ -96,7 +96,7 @@ namespace GherkinSimpleParser.Tests
         }
 
         [Test]
-        public void Should_export_as_CSV_withdocstrings()
+        public void Should_export_as_CSV_with_docstrings()
         {
             // Given
             var converter = new CSVConverter();
@@ -116,6 +116,33 @@ namespace GherkinSimpleParser.Tests
                 ";GENERAL PREREQUISITES:|Prerequisite_0.1|Prere\"q\"uisite_0.2;;",
                 "1;Test Case 1;;",
                 ";Prerequisite_1.1 \"docstrings1 docstrings2\"|Prere\"q\"uisite_1.2;Action_1.1|Action_1.2;Result_1.1|Resu\"l\"t_1.2",
+                "2;Test Case 2;;",
+                ";Prerequisite_2.1|Prere\"q\"uisite_2.2;Action_2.1|Action_2.2;Result_2.1|Resu\"l\"t_2.2"
+            },
+            csvResult);
+        }
+
+        [Test]
+        public void Should_export_as_CSV_with_datatables()
+        {
+            // Given
+            var converter = new CSVConverter();
+            gherkinObject.Scenarios.First().Givens.First().DataTable = new GherkinDataTable
+            {
+                new List<string> { "t1", "t2" },
+                new List<string> { "t3", "t4" },
+            };
+
+            // When
+            var csvResult = converter.ExportAsCSV("|", gherkinObject);
+
+            // Then
+            CollectionAssert.AreEqual(new List<string>()
+            {
+                "Number;GIVEN;WHEN;THEN",
+                ";GENERAL PREREQUISITES:|Prerequisite_0.1|Prere\"q\"uisite_0.2;;",
+                "1;Test Case 1;;",
+                ";Prerequisite_1.1 \"t1 t2 t3 t4\"|Prere\"q\"uisite_1.2;Action_1.1|Action_1.2;Result_1.1|Resu\"l\"t_1.2",
                 "2;Test Case 2;;",
                 ";Prerequisite_2.1|Prere\"q\"uisite_2.2;Action_2.1|Action_2.2;Result_2.1|Resu\"l\"t_2.2"
             },

--- a/GherkinSimpleParser.Tests/ParsingTests/ParsingBasicScenariosTests.cs
+++ b/GherkinSimpleParser.Tests/ParsingTests/ParsingBasicScenariosTests.cs
@@ -98,8 +98,30 @@ namespace GherkinSimpleParser.Tests.ParsingTests
             var result = new GherkinObjectParser(inputLines).Parse();
 
             // Then
-            Assert.That(result.Scenarios.First().When, Is.EqualTo("action"));
-            Assert.That(result.Scenarios.Last().When, Is.EqualTo("action2"));
+            Assert.That(result.Scenarios.First().Whens.First().MainLine, Is.EqualTo("action"));
+            Assert.That(result.Scenarios.Last().Whens.First().MainLine, Is.EqualTo("action2"));
+        }
+
+        [Test]
+        public void Should_parse_given_when_ands_for_scenario()
+        {
+            // Given
+            var inputLines = new List<string>
+            {
+                "   Scenario: Should do something",
+                "       When action",
+                "       And action1",
+                "   Scenario: Should do something else",
+                "       When action2",
+                "       And action3",
+            };
+
+            // When
+            var result = new GherkinObjectParser(inputLines).Parse();
+
+            // Then
+            Assert.That(result.Scenarios.First().Whens.Last().MainLine, Is.EqualTo("action1"));
+            Assert.That(result.Scenarios.Last().Whens.Last().MainLine, Is.EqualTo("action3"));
         }
 
         [Test]

--- a/GherkinSimpleParser.Tests/ParsingTests/ParsingBasicScenariosTests.cs
+++ b/GherkinSimpleParser.Tests/ParsingTests/ParsingBasicScenariosTests.cs
@@ -184,7 +184,6 @@ namespace GherkinSimpleParser.Tests.ParsingTests
         [TestCase("Scenario Template:")]
         [TestCase("Examples:")]
         [TestCase("Scenarios:")]
-        [TestCase("|")]
         public void Should_throw_exception_when_encounters_an_unsupported_line(string startWith)
         {
             // Given

--- a/GherkinSimpleParser.Tests/ParsingTests/ParsingDataTablesTests.cs
+++ b/GherkinSimpleParser.Tests/ParsingTests/ParsingDataTablesTests.cs
@@ -110,5 +110,37 @@ namespace GherkinSimpleParser.Tests.ParsingTests
                 new List<string>{ "w4.2", "w5.2", "w6.2" },
             }, instruciton.DataTable);
         }
+
+        [Test]
+        public void Should_parse_a_data_table_for_scenario_then()
+        {
+            // When
+            var result = new GherkinObjectParser(completeInputLines).Parse();
+
+            // Then
+            var instruciton = result.Scenarios[0].Thens[0];
+            Assert.That(instruciton.MainLine, Is.EqualTo("result"));
+            CollectionAssert.AreEqual(new List<List<string>>
+            {
+                new List<string>{ "t1.1", "t2.1", "t3.1" },
+                new List<string>{ "t4.1", "t5.1", "t6.1" },
+            }, instruciton.DataTable);
+        }
+
+        [Test]
+        public void Should_parse_a_data_table_for_scenario_then_and()
+        {
+            // When
+            var result = new GherkinObjectParser(completeInputLines).Parse();
+
+            // Then
+            var instruciton = result.Scenarios[0].Thens[1];
+            Assert.That(instruciton.MainLine, Is.EqualTo("result1"));
+            CollectionAssert.AreEqual(new List<List<string>>
+            {
+                new List<string>{ "t1.2", "t2.2", "t3.2" },
+                new List<string>{ "t4.2", "t5.2", "t6.2" },
+            }, instruciton.DataTable);
+        }
     }
 }

--- a/GherkinSimpleParser.Tests/ParsingTests/ParsingDataTablesTests.cs
+++ b/GherkinSimpleParser.Tests/ParsingTests/ParsingDataTablesTests.cs
@@ -47,6 +47,38 @@ namespace GherkinSimpleParser.Tests.ParsingTests
         }
 
         [Test]
+        public void Should_parse_a_data_table_for_background_given()
+        {
+            // When
+            var result = new GherkinObjectParser(completeInputLines).Parse();
+
+            // Then
+            var instruciton = result.Background.Givens[0];
+            Assert.That(instruciton.MainLine, Is.EqualTo("prerequisite"));
+            CollectionAssert.AreEqual(new List<List<string>>
+            {
+                new List<string>{ "bg1.1", "bg2.1", "bg3.1" },
+                new List<string>{ "bg4.1", "bg5.1", "bg6.1" },
+            }, instruciton.DataTable);
+        }
+
+        [Test]
+        public void Should_parse_a_data_table_for_background_given_and()
+        {
+            // When
+            var result = new GherkinObjectParser(completeInputLines).Parse();
+
+            // Then
+            var instruciton = result.Background.Givens[1];
+            Assert.That(instruciton.MainLine, Is.EqualTo("prerequisite1"));
+            CollectionAssert.AreEqual(new List<List<string>>
+            {
+                new List<string>{ "bg1.2", "bg2.2", "bg3.2" },
+                new List<string>{ "bg4.2", "bg5.2", "bg6.2" },
+            }, instruciton.DataTable);
+        }
+
+        [Test]
         public void Should_parse_a_data_table_for_scenario_given()
         {
             // When

--- a/GherkinSimpleParser.Tests/ParsingTests/ParsingDataTablesTests.cs
+++ b/GherkinSimpleParser.Tests/ParsingTests/ParsingDataTablesTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace GherkinSimpleParser.Tests.ParsingTests
+{
+    internal class ParsingDataTablesTests
+    {
+        private List<string> completeInputLines;
+
+        [SetUp]
+        public void Setup()
+        {
+            completeInputLines = new List<string>
+            {
+                "   Background:",
+                "       Given prerequisite",
+                "       | 19 | 20 | 21 |",
+                "       | 22 | 23 | 24 |",
+                "       And prerequisite1",
+                "       | 25 | 26 | 27 |",
+                "       | 28 | 29 | 30 |",
+                "   Scenario: Should do something",
+                "       Given prerequisite2",
+                "       | name   | email              | twitter         |",
+                "       | Aslak  | aslak@cucumber.io  | @aslak_hellesoy |",
+                "       | Alice  |   | @alice |",
+                "       And prerequisite3",
+                "       | 1   | 2              | 3         |",
+                "       | 4  | 5  | 6 |",
+                "       When action",
+                "       | 31 | 32 | 33 |",
+                "       | 34 | 35 | 36 |",
+                "       Then result",
+                "       |7|8 | 9|",
+                "       | 10 | 11 | 12 |",
+                "       And result1",
+                "       | 13 | 14 | 15 |",
+                "       | 16 | 17 | 18 |",
+            };
+        }
+
+        [Test]
+        public void Should_parse_a_data_table_for_scenario_given()
+        {
+            // When
+            var result = new GherkinObjectParser(completeInputLines).Parse();
+
+            // Then
+            var instruciton = result.Scenarios[0].Givens[0];
+            Assert.That(instruciton.MainLine, Is.EqualTo("prerequisite2"));
+            CollectionAssert.AreEqual(new List<List<string>>
+            {
+                new List<string>{ "name", "email", "twitter" },
+                new List<string>{ "Aslak", "aslak@cucumber.io", "@aslak_hellesoy" },
+                new List<string>{ "Alice", "", "@alice" }
+            }, instruciton.DataTable);
+        }
+    }
+}

--- a/GherkinSimpleParser.Tests/ParsingTests/ParsingDataTablesTests.cs
+++ b/GherkinSimpleParser.Tests/ParsingTests/ParsingDataTablesTests.cs
@@ -42,7 +42,11 @@ namespace GherkinSimpleParser.Tests.ParsingTests
                 "       | t4.1 | t5.1 | t6.1 |",
                 "       And result1",
                 "       | t1.2 | t2.2 | t3.2 |",
-                "       | t4.2 | t5.2 | t6.2 |"
+                "       | t4.2 | t5.2 | t6.2 |",
+                "   Scenario: Should do something else",
+                "       Given prerequisite sc2",
+                "       | sc2_g1.1 | sc2_g2.1 | sc2_g3.1 |",
+                "       | sc2_g4.1 | sc2_g5.1 | sc2_g6.1 |"
             };
         }
 
@@ -172,6 +176,22 @@ namespace GherkinSimpleParser.Tests.ParsingTests
             {
                 new List<string>{ "t1.2", "t2.2", "t3.2" },
                 new List<string>{ "t4.2", "t5.2", "t6.2" },
+            }, instruciton.DataTable);
+        }
+
+        [Test]
+        public void Should_parse_a_data_table_for_scenario_2_given()
+        {
+            // When
+            var result = new GherkinObjectParser(completeInputLines).Parse();
+
+            // Then
+            var instruciton = result.Scenarios[1].Givens[0];
+            Assert.That(instruciton.MainLine, Is.EqualTo("prerequisite sc2"));
+            CollectionAssert.AreEqual(new List<List<string>>
+            {
+                new List<string>{ "sc2_g1.1", "sc2_g2.1", "sc2_g3.1" },
+                new List<string>{ "sc2_g4.1", "sc2_g5.1", "sc2_g6.1" },
             }, instruciton.DataTable);
         }
     }

--- a/GherkinSimpleParser.Tests/ParsingTests/ParsingDataTablesTests.cs
+++ b/GherkinSimpleParser.Tests/ParsingTests/ParsingDataTablesTests.cs
@@ -59,5 +59,21 @@ namespace GherkinSimpleParser.Tests.ParsingTests
                 new List<string>{ "Alice", "", "@alice" }
             }, instruciton.DataTable);
         }
+
+        [Test]
+        public void Should_parse_a_data_table_for_scenario_given_and()
+        {
+            // When
+            var result = new GherkinObjectParser(completeInputLines).Parse();
+
+            // Then
+            var instruciton = result.Scenarios[0].Givens[1];
+            Assert.That(instruciton.MainLine, Is.EqualTo("prerequisite3"));
+            CollectionAssert.AreEqual(new List<List<string>>
+            {
+                new List<string>{ "1", "2", "3" },
+                new List<string>{ "4", "5", "6" },
+            }, instruciton.DataTable);
+        }
     }
 }

--- a/GherkinSimpleParser.Tests/ParsingTests/ParsingDataTablesTests.cs
+++ b/GherkinSimpleParser.Tests/ParsingTests/ParsingDataTablesTests.cs
@@ -18,11 +18,11 @@ namespace GherkinSimpleParser.Tests.ParsingTests
             {
                 "   Background:",
                 "       Given prerequisite",
-                "       | 19 | 20 | 21 |",
-                "       | 22 | 23 | 24 |",
+                "       | bg1.1 | bg2.1 | bg3.1 |",
+                "       | bg4.1 | bg5.1 | bg6.1 |",
                 "       And prerequisite1",
-                "       | 25 | 26 | 27 |",
-                "       | 28 | 29 | 30 |",
+                "       | bg1.2 | bg2.2 | bg3.2 |",
+                "       | bg4.2 | bg5.2 | bg6.2 |",
                 "   Scenario: Should do something",
                 "       Given prerequisite2",
                 "       | name   | email              | twitter         |",
@@ -30,16 +30,19 @@ namespace GherkinSimpleParser.Tests.ParsingTests
                 "       | Alice  |   | @alice |",
                 "       And prerequisite3",
                 "       | 1   | 2              | 3         |",
-                "       | 4  | 5  | 6 |",
-                "       When action",
-                "       | 31 | 32 | 33 |",
-                "       | 34 | 35 | 36 |",
+                "       |4    |    5|6|",
+                "       When action1",
+                "       | w1.1 | w2.1 | w3.1 |",
+                "       | w4.1 | w5.1 | w6.1 |",
+                "       And action2",
+                "       | w1.2 | w2.2 | w3.2 |",
+                "       | w4.2 | w5.2 | w6.2 |",
                 "       Then result",
-                "       |7|8 | 9|",
-                "       | 10 | 11 | 12 |",
+                "       | t1.1 | t2.1 | t3.1 |",
+                "       | t4.1 | t5.1 | t6.1 |",
                 "       And result1",
-                "       | 13 | 14 | 15 |",
-                "       | 16 | 17 | 18 |",
+                "       | t1.2 | t2.2 | t3.2 |",
+                "       | t4.2 | t5.2 | t6.2 |"
             };
         }
 
@@ -73,6 +76,38 @@ namespace GherkinSimpleParser.Tests.ParsingTests
             {
                 new List<string>{ "1", "2", "3" },
                 new List<string>{ "4", "5", "6" },
+            }, instruciton.DataTable);
+        }
+
+        [Test]
+        public void Should_parse_a_data_table_for_scenario_when()
+        {
+            // When
+            var result = new GherkinObjectParser(completeInputLines).Parse();
+
+            // Then
+            var instruciton = result.Scenarios[0].Whens[0];
+            Assert.That(instruciton.MainLine, Is.EqualTo("action1"));
+            CollectionAssert.AreEqual(new List<List<string>>
+            {
+                new List<string>{ "w1.1", "w2.1", "w3.1" },
+                new List<string>{ "w4.1", "w5.1", "w6.1" },
+            }, instruciton.DataTable);
+        }
+
+        [Test]
+        public void Should_parse_a_data_table_for_scenario_when_and()
+        {
+            // When
+            var result = new GherkinObjectParser(completeInputLines).Parse();
+
+            // Then
+            var instruciton = result.Scenarios[0].Whens[1];
+            Assert.That(instruciton.MainLine, Is.EqualTo("action2"));
+            CollectionAssert.AreEqual(new List<List<string>>
+            {
+                new List<string>{ "w1.2", "w2.2", "w3.2" },
+                new List<string>{ "w4.2", "w5.2", "w6.2" },
             }, instruciton.DataTable);
         }
     }

--- a/GherkinSimpleParser.Tests/ParsingTests/ParsingDocStringsTests.cs
+++ b/GherkinSimpleParser.Tests/ParsingTests/ParsingDocStringsTests.cs
@@ -36,7 +36,16 @@ namespace GherkinSimpleParser.Tests.ParsingTests
                 "       docstring_sc_given_and_1",
                 "       docstring_sc_given_and_2",
                 "       \"\"\"",
-                "       When action",
+                "       When action1",
+                "       \"\"\"",
+                "       docstring_sc_when_1",
+                "       docstring_sc_when_2",
+                "       \"\"\"",
+                "       And action2",
+                "       \"\"\"",
+                "       docstring_sc_when_and_1",
+                "       docstring_sc_when_and_2",
+                "       \"\"\"",
                 "       Then result",
                 "       \"\"\"",
                 "       docstring_sc_then_1",
@@ -68,6 +77,13 @@ namespace GherkinSimpleParser.Tests.ParsingTests
                 CollectionAssert.AreEqual(
                     new List<string> { "docstring_sc_given_and_1", "docstring_sc_given_and_2" },
                     result.Scenarios.First().Givens.Last().DocStrings);
+
+                CollectionAssert.AreEqual(
+                    new List<string> { "docstring_sc_when_1", "docstring_sc_when_2" },
+                    result.Scenarios.First().Whens.First().DocStrings);
+                CollectionAssert.AreEqual(
+                    new List<string> { "docstring_sc_when_and_1", "docstring_sc_when_and_2" },
+                    result.Scenarios.First().Whens.Last().DocStrings);
 
                 CollectionAssert.AreEqual(
                     new List<string> { "docstring_sc_then_1", "docstring_sc_then_2" },

--- a/GherkinSimpleParser/GherkinDataTable.cs
+++ b/GherkinSimpleParser/GherkinDataTable.cs
@@ -1,0 +1,6 @@
+﻿namespace GherkinSimpleParser
+{
+    public class GherkinDataTable : List<List<string>>
+    {
+    }
+}

--- a/GherkinSimpleParser/GherkinObjectParser.cs
+++ b/GherkinSimpleParser/GherkinObjectParser.cs
@@ -41,6 +41,7 @@ namespace GherkinSimpleParser
             OTHER,
             BACKGROUND_GIVEN,
             SCENARIO_GIVEN,
+            SCENARIO_WHEN,
             SCENARIO_THEN,
         }
 
@@ -88,6 +89,8 @@ namespace GherkinSimpleParser
                         break;
                     case FillingState.SCENARIO_GIVEN:
                         result.Scenarios.Last().Givens.Last().DataTable.Add(tableRow);
+                        break;
+                    case FillingState.SCENARIO_WHEN:
                         break;
                     case FillingState.SCENARIO_THEN:
                         break;
@@ -152,6 +155,7 @@ namespace GherkinSimpleParser
         private void HandleWhenLine()
         {
             currentScenario.When = TrimedLine.Substring(5);
+            fillingState = FillingState.SCENARIO_WHEN;
         }
 
         private void HandleGivenLine()

--- a/GherkinSimpleParser/GherkinObjectParser.cs
+++ b/GherkinSimpleParser/GherkinObjectParser.cs
@@ -94,6 +94,7 @@ namespace GherkinSimpleParser
                         result.Scenarios.Last().Whens.Last().DataTable.Add(tableRow);
                         break;
                     case FillingState.SCENARIO_THEN:
+                        result.Scenarios.Last().Thens.Last().DataTable.Add(tableRow);
                         break;
                     default:
                         break;

--- a/GherkinSimpleParser/GherkinObjectParser.cs
+++ b/GherkinSimpleParser/GherkinObjectParser.cs
@@ -91,6 +91,7 @@ namespace GherkinSimpleParser
                         result.Scenarios.Last().Givens.Last().DataTable.Add(tableRow);
                         break;
                     case FillingState.SCENARIO_WHEN:
+                        result.Scenarios.Last().Whens.Last().DataTable.Add(tableRow);
                         break;
                     case FillingState.SCENARIO_THEN:
                         break;

--- a/GherkinSimpleParser/GherkinObjectParser.cs
+++ b/GherkinSimpleParser/GherkinObjectParser.cs
@@ -125,6 +125,9 @@ namespace GherkinSimpleParser
                     case FillingState.SCENARIO_GIVEN:
                         currentScenario.Givens.Last().DocStrings.Add(indentedLine);
                         break;
+                    case FillingState.SCENARIO_WHEN:
+                        currentScenario.Whens.Last().DocStrings.Add(indentedLine);
+                        break;
                     case FillingState.SCENARIO_THEN:
                         currentScenario.Thens.Last().DocStrings.Add(indentedLine);
                         break;

--- a/GherkinSimpleParser/GherkinObjectParser.cs
+++ b/GherkinSimpleParser/GherkinObjectParser.cs
@@ -10,7 +10,7 @@ namespace GherkinSimpleParser
     {
         private readonly List<string> inputLines;
         private readonly GherkinObject result;
-        private readonly Queue<string> linesStack;
+        private readonly Stack<string> linesStack;
 
         private Scenario currentScenario;
         private FillingState fillingState;
@@ -24,7 +24,9 @@ namespace GherkinSimpleParser
         public GherkinObjectParser(List<string> inputLines)
         {
             this.inputLines = inputLines;
-            linesStack = new Queue<string>(inputLines);
+            var inputLineReversed = new List<string>(inputLines);
+            inputLineReversed.Reverse();
+            linesStack = new Stack<string>(inputLineReversed);
             result = new GherkinObject();
 
             fillingState = FillingState.OTHER;
@@ -53,7 +55,7 @@ namespace GherkinSimpleParser
         {
             while (linesStack.Count > 0)
             {
-                currentLine = linesStack.Dequeue();
+                currentLine = linesStack.Pop();
                 lineCount++;
 
                 if (TrimedLine.StartsWith("#") || string.IsNullOrEmpty(TrimedLine)) continue;
@@ -66,18 +68,48 @@ namespace GherkinSimpleParser
                 else if (TrimedLine.StartsWith("Then ")) HandleThenLine();
                 else if (TrimedLine.StartsWith("And ")) HandleAndLine();
                 else if (TrimedLine.StartsWith("\"\"\"")) HandleDocStringsBlock();
+                else if (TrimedLine.StartsWith("|")) HandleDataTableBlock();
                 else throw new ArgumentException($"Line {lineCount}: Unsupported line: \"{TrimedLine}\"", nameof(inputLines));
             }
 
             return result;
         }
 
+        private void HandleDataTableBlock()
+        {
+            while (TrimedLine.StartsWith("|"))
+            {
+                var tableRow = TrimedLine.Split("|", StringSplitOptions.TrimEntries).Skip(1).SkipLast(1).ToList();
+                switch (fillingState)
+                {
+                    case FillingState.OTHER:
+                        break;
+                    case FillingState.BACKGROUND_GIVEN:
+                        break;
+                    case FillingState.SCENARIO_GIVEN:
+                        result.Scenarios.Last().Givens.Last().DataTable.Add(tableRow);
+                        break;
+                    case FillingState.SCENARIO_THEN:
+                        break;
+                    default:
+                        break;
+                }
+
+                if (linesStack.Count == 0)
+                    return;
+
+                currentLine = linesStack.Pop();
+                lineCount++;
+            }
+            linesStack.Push(currentLine);
+        }
+
         private void HandleDocStringsBlock()
         {
             int indentCountReference = currentLine.IndexOf('"');
-            currentLine = linesStack.Dequeue();
+            currentLine = linesStack.Pop();
             lineCount++;
-            while (!currentLine.Trim().StartsWith("\"\"\""))
+            while (!TrimedLine.StartsWith("\"\"\""))
             {
                 int firstCharIndex = string.IsNullOrEmpty(currentLine) ? 0 : currentLine.IndexOf(currentLine.Trim().First());
                 int leadingZerosToAdd = firstCharIndex - indentCountReference >= 0 ? firstCharIndex - indentCountReference : 0;
@@ -96,7 +128,7 @@ namespace GherkinSimpleParser
                     default:
                         throw new StateMachineException($"State {fillingState} is not allowed to contain DocString");
                 }
-                currentLine = linesStack.Dequeue();
+                currentLine = linesStack.Pop();
                 lineCount++;
             }
         }

--- a/GherkinSimpleParser/GherkinObjectParser.cs
+++ b/GherkinSimpleParser/GherkinObjectParser.cs
@@ -83,18 +83,17 @@ namespace GherkinSimpleParser
                 var tableRow = TrimedLine.Split("|", StringSplitOptions.TrimEntries).Skip(1).SkipLast(1).ToList();
                 switch (fillingState)
                 {
-                    case FillingState.OTHER:
-                        break;
                     case FillingState.BACKGROUND_GIVEN:
+                        result.Background.Givens.Last().DataTable.Add(tableRow);
                         break;
                     case FillingState.SCENARIO_GIVEN:
-                        result.Scenarios.Last().Givens.Last().DataTable.Add(tableRow);
+                        currentScenario.Givens.Last().DataTable.Add(tableRow);
                         break;
                     case FillingState.SCENARIO_WHEN:
-                        result.Scenarios.Last().Whens.Last().DataTable.Add(tableRow);
+                        currentScenario.Whens.Last().DataTable.Add(tableRow);
                         break;
                     case FillingState.SCENARIO_THEN:
-                        result.Scenarios.Last().Thens.Last().DataTable.Add(tableRow);
+                        currentScenario.Thens.Last().DataTable.Add(tableRow);
                         break;
                     default:
                         break;

--- a/GherkinSimpleParser/GherkinObjectParser.cs
+++ b/GherkinSimpleParser/GherkinObjectParser.cs
@@ -138,12 +138,23 @@ namespace GherkinSimpleParser
 
         private void HandleAndLine()
         {
-            if (fillingState == FillingState.SCENARIO_GIVEN)
-                currentScenario.Givens.Add(new Instruction(TrimedLine.Substring(4)));
-            else if (fillingState == FillingState.SCENARIO_THEN)
-                currentScenario.Thens.Add(new Instruction(TrimedLine.Substring(4)));
-            else if (fillingState == FillingState.BACKGROUND_GIVEN)
-                result.Background.Givens.Add(new Instruction(TrimedLine.Substring(4)));
+            switch (fillingState)
+            {
+                case FillingState.BACKGROUND_GIVEN:
+                    result.Background.Givens.Add(new Instruction(TrimedLine.Substring(4)));
+                    break;
+                case FillingState.SCENARIO_GIVEN:
+                    currentScenario.Givens.Add(new Instruction(TrimedLine.Substring(4)));
+                    break;
+                case FillingState.SCENARIO_WHEN:
+                    currentScenario.Whens.Add(new Instruction(TrimedLine.Substring(4)));
+                    break;
+                case FillingState.SCENARIO_THEN:
+                    currentScenario.Thens.Add(new Instruction(TrimedLine.Substring(4)));
+                    break;
+                default:
+                    break;
+            }
         }
 
         private void HandleThenLine()
@@ -154,7 +165,7 @@ namespace GherkinSimpleParser
 
         private void HandleWhenLine()
         {
-            currentScenario.When = TrimedLine.Substring(5);
+            currentScenario.Whens.Add(new Instruction(TrimedLine.Substring(5)));
             fillingState = FillingState.SCENARIO_WHEN;
         }
 

--- a/GherkinSimpleParser/Instruction.cs
+++ b/GherkinSimpleParser/Instruction.cs
@@ -9,5 +9,6 @@
 
         public string MainLine { get; set; }
         public List<string> DocStrings { get; set; } = new();
+        public GherkinDataTable DataTable { get; set; } = new();
     }
 }

--- a/GherkinSimpleParser/Scenario.cs
+++ b/GherkinSimpleParser/Scenario.cs
@@ -4,7 +4,7 @@
     {
         public string Name { get; set; }
         public List<Instruction> Givens { get; set; } = new();
-        public string When { get; set; }
+        public List<Instruction> Whens { get; set; } = new();
         public List<Instruction> Thens { get; set; } = new();
         public List<string> Tags { get; set; }
     }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ var gherkinObj = new GherkinObjectParser(lines).Parse();
 * `And` (when, multiple)
 * `Then`
 * `And` (then, multiple)
-* `"""` (Doc Strings) (for Given, Then)
+* `"""` (Doc Strings) (for Given, When, Then, And)
+* `|` (Data Tables) (for Given, When, Then, And)
 * `@` (Tags) (Before Scenario and Feature)
 
 ## Ignores
@@ -37,7 +38,6 @@ var gherkinObj = new GherkinObjectParser(lines).Parse();
 * `*`
 * `Scenario Outline` (or `Scenario Template`)
 * `Examples` (or `Scenarios`)
-* `|` (Data Tables)
 
 # Exports
 
@@ -53,7 +53,7 @@ Using the applicaiton extension `GherkinSimpleParser.Converter` you have access 
 
 ### To be noted
 
-New lines and carriage return are removed from Doc strings (`"""`).
+New lines and carriage return are removed from Doc strings (`"""`) and from Data Tables (`|`).
 
 ### Export as CSV for testplan with \<speparator> for ANDs
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ var gherkinObj = new GherkinObjectParser(lines).Parse();
 * `Scenario` (multiple)
 * `Given`
 * `And` (given, multiple)
-* `When` (unique)
+* `When`
+* `And` (when, multiple)
 * `Then`
 * `And` (then, multiple)
 * `"""` (Doc Strings) (for Given, Then)


### PR DESCRIPTION
# Add support for data tables

### Description

Allows using datatables in parsing and export.

### Changes Made

- Add pparsing for datatables
- Add CSV export for datatables
- Add excel export for datatables
- Transformed `When` into an instruction
- Added docstrings support for `When`
- Updated documentations

### Testing Done

- [x] Unit tests passed

### Related Issues

 Closes #7 
